### PR TITLE
CORE-1442: add request limits

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"database/sql"
+	"encoding/json"
 	"net/http"
 
 	"github.com/cyverse-de/requests/clients/iplantemail"
@@ -36,9 +37,26 @@ type RootResponse struct {
 	Version string `json:"Version"`
 }
 
-// ErrorResponse describes an error response for any endpoint.
+// ErrorResponse describes an error response for any endpoint. This type implements the error interface so that it can
+// be returned as an error from existing functions.
 type ErrorResponse struct {
-	Message string `json:"message"`
+	Message   string                  `json:"message"`
+	ErrorCode string                  `json:"error_code,omitempty"`
+	Details   *map[string]interface{} `json:"details,omitempty"`
+}
+
+// ErrorBytes returns a byte-array representation of an ErrorResponse.
+func (e ErrorResponse) ErrorBytes() []byte {
+	bytes, err := json.Marshal(e)
+	if err != nil {
+		return make([]byte, 0)
+	}
+	return bytes
+}
+
+// Error returns a string representation of an ErrorResponse.
+func (e ErrorResponse) Error() string {
+	return string(e.ErrorBytes())
 }
 
 // RootHandler handles GET requests to the / endpoint.

--- a/api/main_docs.go
+++ b/api/main_docs.go
@@ -92,6 +92,11 @@ type registerRequestTypeParameters struct {
 	//
 	// in:path
 	Name string
+
+	// the maximum number of requests of the given type that a user may submit
+	//
+	// in:query
+	MaximumRequestsPerUser *int32 `json:"maximum-requests-per-user"`
 }
 
 // swagger:route GET /request-status-codes request-status-codes getRequestStatusCodes

--- a/api/main_docs.go
+++ b/api/main_docs.go
@@ -48,6 +48,7 @@ type errorResponseWrapper struct {
 //
 // responses:
 //    200: requestTypeListing
+//    500: errorResponse
 
 // Request type listing response
 // swagger:response requestTypeListing
@@ -67,6 +68,7 @@ type requestTypeListingWrapper struct {
 // responses:
 //   200: requestType
 //   400: errorResponse
+//   500: errorResponse
 
 // swagger:route GET /request-types/{name} request-types getRequestType
 //
@@ -77,6 +79,7 @@ type requestTypeListingWrapper struct {
 // responses:
 //   200: requestType
 //   404: errorResponse
+//   500: errorResponse
 
 // Request type response
 // swagger:response requestType
@@ -107,6 +110,7 @@ type registerRequestTypeParameters struct {
 //
 // responses:
 //    200: requestStatusCodeListing
+//    500: errorResponse
 
 // Request status code listing response
 // swagger:response requestStatusCodeListing
@@ -123,6 +127,8 @@ type requestStatusCodeListingWrapper struct {
 //
 // Responses:
 //   200: requestSummary
+//   400: errorResponse
+//   500: errorResponse
 
 // Request summary information
 // swagger:response requestSummary
@@ -154,6 +160,8 @@ type requestSubmissionParameters struct {
 //
 // Responses:
 //   200: requestListing
+//   400: errorResponse
+//   500: errorResponse
 
 // Request listing
 // swagger:response requestListing
@@ -189,6 +197,8 @@ type requestListingParameters struct {
 //
 // Responses:
 //   200: requestDetails
+//   404: errorResponse
+//   500: errorResponse
 
 // Request detail information
 // swagger:response requestDetails
@@ -214,6 +224,9 @@ type getRequestInformationParameters struct {
 //
 // Responses:
 //   200: requestUpdate
+//   400: errorResponse
+//   404: errorResponse
+//   500: errorResponse
 
 // Request update information
 // swagger:response requestUpdate

--- a/api/requests.go
+++ b/api/requests.go
@@ -156,7 +156,7 @@ func (a *API) GetRequestsHandler(ctx echo.Context) error {
 	}
 	defer tx.Rollback()
 
-	// Extract and validate the user query parameter.
+	// Extract and validate the include-completed query parameter.
 	defaultIncludeCompleted := false
 	includeCompleted, err := query.ValidateBooleanQueryParam(ctx, "include-completed", &defaultIncludeCompleted)
 	if err != nil {

--- a/api/requests.go
+++ b/api/requests.go
@@ -95,14 +95,14 @@ func (a *API) AddRequestHandler(ctx echo.Context) error {
 			return err
 		}
 		if count >= *requestType.MaximumRequestsPerUser {
-
-			// We use a 402 rather than a 403 because a 403 might confuse callers and no other status code really fits.
-			return ctx.JSON(http.StatusPaymentRequired, ErrorResponse{
-				Message: fmt.Sprintf(
-					"the number of previously submitted requests (%d) meets or exceeds the maximum (%d)",
-					count,
-					*requestType.MaximumRequestsPerUser,
-				),
+			return ctx.JSON(http.StatusBadRequest, ErrorResponse{
+				Message:   fmt.Sprintf("no more requests of type '%s' may be submitted", requestType.Name),
+				ErrorCode: "ERR_LIMIT_REACHED",
+				Details: &map[string]interface{}{
+					"requestType":       requestType.Name,
+					"maximumRequests":   *requestType.MaximumRequestsPerUser,
+					"submittedRequests": count,
+				},
 			})
 		}
 	}

--- a/db/request_types.go
+++ b/db/request_types.go
@@ -15,7 +15,7 @@ func requestTypesFromRows(rows *sql.Rows) ([]*model.RequestType, error) {
 	// Build the list of request types.
 	for rows.Next() {
 		var rt model.RequestType
-		err := rows.Scan(&rt.ID, &rt.Name)
+		err := rows.Scan(&rt.ID, &rt.Name, &rt.MaximumRequestsPerUser)
 		if err != nil {
 			return nil, err
 		}
@@ -27,7 +27,7 @@ func requestTypesFromRows(rows *sql.Rows) ([]*model.RequestType, error) {
 
 // ListRequestTypes returns a listing of request types from the database sorted by name.
 func ListRequestTypes(tx *sql.Tx) ([]*model.RequestType, error) {
-	query := "SELECT id, name FROM request_types ORDER BY name"
+	query := "SELECT id, name, maximum_requests_per_user FROM request_types ORDER BY name"
 
 	// Query the database.
 	rows, err := tx.Query(query)
@@ -42,7 +42,7 @@ func ListRequestTypes(tx *sql.Tx) ([]*model.RequestType, error) {
 
 // GetRequestType returns the request type with the given name if it exists.
 func GetRequestType(tx *sql.Tx, name string) (*model.RequestType, error) {
-	query := "SELECT id, name FROM request_types WHERE name = $1"
+	query := "SELECT id, name, maximum_requests_per_user FROM request_types WHERE name = $1"
 
 	// Query the database.
 	rows, err := tx.Query(query, name)
@@ -63,13 +63,13 @@ func GetRequestType(tx *sql.Tx, name string) (*model.RequestType, error) {
 }
 
 // AddRequestType adds a request type with the given name.
-func AddRequestType(tx *sql.Tx, name string) (*model.RequestType, error) {
-	query := `INSERT INTO request_types (name)
-			  VALUES ($1)
-			  RETURNING id, name`
+func AddRequestType(tx *sql.Tx, name string, maximumRequestsPerUser *int32) (*model.RequestType, error) {
+	query := `INSERT INTO request_types (name, maximum_requests_per_user)
+			  VALUES ($1, $2)
+			  RETURNING id, name, maximum_requests_per_user`
 
 	// Insert the new request type.
-	rows, err := tx.Query(query, name)
+	rows, err := tx.Query(query, name, maximumRequestsPerUser)
 	if err != nil {
 		return nil, err
 	}

--- a/db/requests.go
+++ b/db/requests.go
@@ -11,6 +11,26 @@ import (
 	"github.com/pkg/errors"
 )
 
+// CountRequestsOfType counts the number of requests of the given type that have been submitted by the given user.
+func CountRequestsOfType(tx *sql.Tx, userID, requestTypeID string) (int32, error) {
+
+	// Prepare the query.
+	query, args, err := psql.Select("count(*)").
+		From("requests").
+		Where(sq.Eq{"requesting_user_id": userID}).
+		Where(sq.Eq{"request_type_id": requestTypeID}).
+		ToSql()
+	if err != nil {
+		return 0, err
+	}
+
+	// Query the database and extract the count.
+	var count int32
+	row := tx.QueryRow(query, args...)
+	err = row.Scan(&count)
+	return count, err
+}
+
 // AddRequest adds a new request to the database.
 func AddRequest(tx *sql.Tx, userID, requestTypeID string, details interface{}) (string, error) {
 	query := `INSERT INTO requests (request_type_id, requesting_user_id, details)

--- a/model/request_types.go
+++ b/model/request_types.go
@@ -7,6 +7,9 @@ type RequestType struct {
 
 	// the request type name
 	Name string `json:"name"`
+
+	// the maximum number of requests of this type that a user may submit
+	MaximumRequestsPerUser *int32 `json:"maximum_requests_per_user,omitempty"`
 }
 
 // RequestTypeListing describes a listing of request types.

--- a/query/main.go
+++ b/query/main.go
@@ -60,7 +60,7 @@ func ValidateOptionalIntQueryParam(ctx echo.Context, name string) (*int32, error
 		return nil, nil
 	}
 
-	// Parase the parameter value and return the result.
+	// Parse the parameter value and return the result.
 	parsed, err := strconv.ParseInt(value, 10, 32)
 	if err != nil {
 		return nil, errors.Wrap(err, errMsg)

--- a/query/main.go
+++ b/query/main.go
@@ -48,3 +48,23 @@ func ValidateBooleanQueryParam(ctx echo.Context, name string, defaultValue *bool
 	}
 	return result, nil
 }
+
+// ValidateOptionalIntQueryParam extracts an optional integer query parameter and validates it. This function returns
+// nil if the parameter is not specified.
+func ValidateOptionalIntQueryParam(ctx echo.Context, name string) (*int32, error) {
+	errMsg := fmt.Sprintf("invalid query parameter: %s", name)
+	value := ctx.QueryParam(name)
+
+	// If no value was provided, simply return nil.
+	if value == "" {
+		return nil, nil
+	}
+
+	// Parase the parameter value and return the result.
+	parsed, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		return nil, errors.Wrap(err, errMsg)
+	}
+	result := int32(parsed)
+	return &result, nil
+}


### PR DESCRIPTION
This change allows the Discovery Environment to impose a limit on the number of administrative requests of a specific type that a user may submit. The initial use case is to permit DE users to submit at most one VICE access request.
