### PR TITLE
CORE-1452: support limits for maximum number of active requests

### DIFF
--- a/api/main_docs.go
+++ b/api/main_docs.go
@@ -100,6 +100,11 @@ type registerRequestTypeParameters struct {
 	//
 	// in:query
 	MaximumRequestsPerUser *int32 `json:"maximum-requests-per-user"`
+
+	// the maximum number of active requests that a user may have submitted at any given time
+	//
+	// in:query
+	MaximumConcurrentRequestsPerUser *int32 `json:"maximum-concurrent-requests-per-user"`
 }
 
 // swagger:route GET /request-status-codes request-status-codes getRequestStatusCodes

--- a/db/request_types.go
+++ b/db/request_types.go
@@ -15,7 +15,7 @@ func requestTypesFromRows(rows *sql.Rows) ([]*model.RequestType, error) {
 	// Build the list of request types.
 	for rows.Next() {
 		var rt model.RequestType
-		err := rows.Scan(&rt.ID, &rt.Name, &rt.MaximumRequestsPerUser)
+		err := rows.Scan(&rt.ID, &rt.Name, &rt.MaximumRequestsPerUser, &rt.MaximumConcurrentRequestsPerUser)
 		if err != nil {
 			return nil, err
 		}
@@ -27,7 +27,9 @@ func requestTypesFromRows(rows *sql.Rows) ([]*model.RequestType, error) {
 
 // ListRequestTypes returns a listing of request types from the database sorted by name.
 func ListRequestTypes(tx *sql.Tx) ([]*model.RequestType, error) {
-	query := "SELECT id, name, maximum_requests_per_user FROM request_types ORDER BY name"
+	query := `SELECT id, name, maximum_requests_per_user, maximum_concurrent_requests_per_user
+	          FROM request_types
+			  ORDER BY name`
 
 	// Query the database.
 	rows, err := tx.Query(query)
@@ -42,7 +44,9 @@ func ListRequestTypes(tx *sql.Tx) ([]*model.RequestType, error) {
 
 // GetRequestType returns the request type with the given name if it exists.
 func GetRequestType(tx *sql.Tx, name string) (*model.RequestType, error) {
-	query := "SELECT id, name, maximum_requests_per_user FROM request_types WHERE name = $1"
+	query := `SELECT id, name, maximum_requests_per_user, maximum_concurrent_requests_per_user
+	          FROM request_types
+			  WHERE name = $1`
 
 	// Query the database.
 	rows, err := tx.Query(query, name)

--- a/db/request_types.go
+++ b/db/request_types.go
@@ -67,13 +67,15 @@ func GetRequestType(tx *sql.Tx, name string) (*model.RequestType, error) {
 }
 
 // AddRequestType adds a request type with the given name.
-func AddRequestType(tx *sql.Tx, name string, maximumRequestsPerUser *int32) (*model.RequestType, error) {
-	query := `INSERT INTO request_types (name, maximum_requests_per_user)
-			  VALUES ($1, $2)
-			  RETURNING id, name, maximum_requests_per_user`
+func AddRequestType(tx *sql.Tx, name string, maximumRequestsPerUser, maximumConcurrentRequestsPerUser *int32) (
+	*model.RequestType, error,
+) {
+	query := `INSERT INTO request_types (name, maximum_requests_per_user, maximum_concurrent_requests_per_user)
+			  VALUES ($1, $2, $3)
+			  RETURNING id, name, maximum_requests_per_user, maximum_concurrent_requests_per_user`
 
 	// Insert the new request type.
-	rows, err := tx.Query(query, name, maximumRequestsPerUser)
+	rows, err := tx.Query(query, name, maximumRequestsPerUser, maximumConcurrentRequestsPerUser)
 	if err != nil {
 		return nil, err
 	}

--- a/model/request_types.go
+++ b/model/request_types.go
@@ -8,6 +8,9 @@ type RequestType struct {
 	// the request type name
 	Name string `json:"name"`
 
+	// The maximum number of concurrently active requests that a user may submit
+	MaximumConcurrentRequestsPerUser *int32 `json:"maximum_concurrent_requests_per_user,omitempty"`
+
 	// the maximum number of requests of this type that a user may submit
 	MaximumRequestsPerUser *int32 `json:"maximum_requests_per_user,omitempty"`
 }


### PR DESCRIPTION
This change allows administrators to set the maximum number of currently active requests for any given request type. If the user tries to submit more than the current maximum, the following error will be returned:

```
{
  "message": "no more active requests of type 'vice' may be submitted",
  "error_code": "ERR_LIMIT_REACHED",
  "details": {
    "activeSubmittedRequests": 1,
    "maximumActiveRequests": 1,
    "requestType": "vice"
  }
}
```

An overall maximum is still supported, and the error response that is returned is the same in that case:

```
{
  "message": "no more requests of type 'vice' may be submitted",
  "error_code": "ERR_LIMIT_REACHED",
  "details": {
    "maximumRequests": 10,
    "requestType": "vice",
    "submittedRequests": 10
  }
}
```

We're going to want to have the ability to change the limits, but that's beyond the scope of this change.
